### PR TITLE
[SPARK-ALARM-1]Add job level error notification and batch process timeout  notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ git https://github.com/yaooqinn/spark-alarm.git
 | ------ | ------ | ------ |
 | spark.alarm.streaming.application.force.exit | false | 出现Application级别错误的时候，是否直接exit |
 | spark.alarm.streaming.batch.error.enable | true | 是否对Batch出错的信息进行告警 |
+| spark.alarm.streaming.job.error.enable | false | 是否对job出错的信息进行告警 |
 | spark.alarm.streaming.batch.delay.ratio | 1 | Schedule delay时间 / Processing 时间的比值，大于该值，则作为判定为需要告警的必要条件之一  |
 | spark.alarm.streaming.batch.process.time.threshold | 1s | 处理时间的阈值，实际处理时间大于该值的批次，才进行报警 |
 

--- a/alarm-common/src/main/scala/com/netease/spark/alarm/AlarmConstants.scala
+++ b/alarm-common/src/main/scala/com/netease/spark/alarm/AlarmConstants.scala
@@ -12,6 +12,8 @@ object AlarmConstants {
   val STREAMING_BATCH_ERROR: String =
     "服务[" + SERVICE + "]-组件["+ STREAMING + "]-级别[" + Batch + "] 异常告警"
 
+  val STREAMING_JOB_ERROR: String =
+    "服务[" + SERVICE + "]-组件["+ STREAMING + "]-级别[" + Job + "] 异常告警"
 }
 
 

--- a/alarm-smilodon/src/main/scala/com/netease/spark/alarm/smilodon/event/SmilodonEvent.scala
+++ b/alarm-smilodon/src/main/scala/com/netease/spark/alarm/smilodon/event/SmilodonEvent.scala
@@ -17,4 +17,6 @@ object SmilodonEvent {
   def streamingBatchEvent(): SmilodonEvent =
     SmilodonEvent(AlarmConstants.SERVICE, Components.STREAMING.toString, AlertType.Batch.toString)
 
+  def streamingJobEvent(): SmilodonEvent =
+    SmilodonEvent(AlarmConstants.SERVICE, Components.STREAMING.toString, AlertType.Job.toString)
 }

--- a/streaming-alarmer/src/main/scala/com/netease/spark/alarm/alarmer/streaming/StreamingAlarmListener.scala
+++ b/streaming-alarmer/src/main/scala/com/netease/spark/alarm/alarmer/streaming/StreamingAlarmListener.scala
@@ -2,18 +2,23 @@ package com.netease.spark.alarm.alarmer.streaming
 
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.concurrent.ConcurrentHashMap
 
 import com.netease.spark.alarm.{Alarmist, AlertMessage}
 import com.netease.spark.alarm.AlarmConstants._
 import org.apache.commons.logging.LogFactory
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd, SparkListenerApplicationStart, SparkListenerEvent}
-import org.apache.spark.streaming.scheduler.{StreamingListener, StreamingListenerBatchCompleted}
+import org.apache.spark.streaming.scheduler.{StreamingListener, StreamingListenerBatchCompleted, StreamingListenerBatchStarted, StreamingListenerOutputOperationCompleted}
 import org.apache.spark.SparkConf
-import org.apache.spark.streaming.StreamingContext
+import org.apache.spark.streaming.{StreamingContext, Time}
 
 import scala.util.{Success, Try}
+import scala.collection.JavaConverters._
 
 trait StreamingAlarmListener extends SparkListener with StreamingListener {
+
+  import StreamingAlarmListener._
+
   private val LOG = LogFactory.getFactory.getInstance(classOf[StreamingAlarmListener])
 
   protected def alarmist: Alarmist
@@ -26,9 +31,13 @@ trait StreamingAlarmListener extends SparkListener with StreamingListener {
   protected val batchNoticeEnable: Boolean = conf.getBoolean(BATCH_NOTICE_ENABLE, defaultValue = true)
   protected val batchDelayRatio: Double = conf.getDouble(BATCH_DELAY_RATIO, 1)
   protected val batchProcessThreshold: Long = conf.getTimeAsMs(BATCH_PROCESS_TIME, "1s")
+  protected lazy val batchSet: java.util.Map[Time, Long] = new ConcurrentHashMap[Time, Long]
 
+  protected val jobNoticeEnable: Boolean = conf.getBoolean(JOB_NOTICE_ENABLE, defaultValue = false)
 
   override def onApplicationStart(applicationStart: SparkListenerApplicationStart): Unit = {
+    if (LOG.isDebugEnabled) LOG.debug(s"onApplicationStart called: $applicationStart")
+
     StreamingContext.getActive().foreach { ssc =>
       val context = ssc.sparkContext
       applicationId = context.applicationId
@@ -43,6 +52,7 @@ trait StreamingAlarmListener extends SparkListener with StreamingListener {
    */
   override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
     if (LOG.isDebugEnabled) LOG.debug(s"onApplicationEnd called: $applicationEnd")
+
     val maybeContext = StreamingContext.getActive()
     maybeContext.foreach { ssc =>
       val context = ssc.sparkContext
@@ -63,16 +73,37 @@ trait StreamingAlarmListener extends SparkListener with StreamingListener {
    * In [[SparkListener]]s, wrapped streaming events first come here
    */
   override def onOtherEvent(event: SparkListenerEvent): Unit = {
-    if (LOG.isDebugEnabled) LOG.debug(s"onApplicationEnd called: $event")
+    if (LOG.isDebugEnabled) LOG.debug(s"onOtherEvent called: $event")
 
     Try { event.getClass.getDeclaredField("streamingListenerEvent") } match {
       case Success(field) =>
         field.setAccessible(true)
         field.get(event) match {
+          case as: SparkListenerApplicationStart => onApplicationStart(as)
+          case ae: SparkListenerApplicationEnd => onApplicationEnd(ae)
+          case bs: StreamingListenerBatchStarted => onBatchStarted(bs)
           case bc: StreamingListenerBatchCompleted => onBatchCompleted(bc)
+          case oc: StreamingListenerOutputOperationCompleted => onOutputOperationCompleted(oc)
           case _ =>
         }
       case _ =>
+    }
+  }
+
+  override def onBatchStarted(batchStarted: StreamingListenerBatchStarted): Unit = {
+    if (LOG.isDebugEnabled) LOG.debug(s"onBatchStarted called: $batchStarted")
+
+    if (batchNoticeEnable) {
+      val currentTime = System.currentTimeMillis()
+      batchSet.entrySet().asScala.foreach { kv =>
+        val start = kv.getValue
+        if (currentTime - start > batchProcessThreshold) {
+          alarmist.alarm(AlertMessage(STREAMING_BATCH_ERROR,
+            batchTimeoutContent(currentTime - start)))
+        }
+      }
+      val batchInfo = batchStarted.batchInfo
+      batchSet.put(batchInfo.batchTime, batchInfo.processingStartTime.getOrElse(System.currentTimeMillis()))
     }
   }
 
@@ -82,6 +113,7 @@ trait StreamingAlarmListener extends SparkListener with StreamingListener {
     val info = batchCompleted.batchInfo
 
     if (batchNoticeEnable) {
+      batchSet.remove(info.batchTime)
       val batchFailureReasons = info.outputOperationInfos.values.map(_.failureReason).filter(_.nonEmpty).mkString("\n")
       if (batchFailureReasons.nonEmpty) {
         val content = batchErrorContent(batchFailureReasons)
@@ -97,28 +129,65 @@ trait StreamingAlarmListener extends SparkListener with StreamingListener {
     }
   }
 
+  override def onOutputOperationCompleted(outputOperationCompleted: StreamingListenerOutputOperationCompleted): Unit = {
+    if (LOG.isDebugEnabled) LOG.debug(s"onOutputOperationCompleted called: $outputOperationCompleted")
+
+    if (jobNoticeEnable) {
+      val jobFailureReason = outputOperationCompleted.outputOperationInfo.failureReason
+      jobFailureReason.foreach { reason =>
+        alarmist.alarm(AlertMessage(STREAMING_JOB_ERROR, jobErrorContent(reason)))
+      }
+    }
+  }
+
   protected def batchDelayContent(schedulingDelay: Long, processingDelay: Long): String = {
     s"""
        |$STREAMING_BATCH_ERROR
        |
-           |作业名: $appName
+       |作业名: $appName
        |作业ID: $applicationId
        |诊断信息:
        |  批次调度延时过高(Scheduling Delay: $schedulingDelay ms / Processing Time: $processingDelay ms > $batchDelayRatio )
        |  单独关闭该类型警报可设置 $BATCH_DELAY_RATIO 的值
-         """.stripMargin
+     """.stripMargin
   }
 
   protected def batchErrorContent(batchFailureReasons: String): String = {
     s"""
        |$STREAMING_BATCH_ERROR
        |
-             |作业名: $appName
+       |作业名: $appName
        |作业ID: $applicationId
        |诊断信息:
-       |  $batchFailureReasons
+       |  (长度限制: $failureReasonLimit)
+       |  ${getLimitFailureReason(batchFailureReasons)}
        |  单独关闭该类型警报可设置$BATCH_NOTICE_ENABLE=false
-           """.stripMargin
+     """.stripMargin
+  }
+
+  protected def batchTimeoutContent(processDuration: Long): String = {
+    s"""
+       |$STREAMING_BATCH_ERROR
+       |
+       |作业名: $appName
+       |作业ID: $applicationId
+       |诊断信息:
+       |  批次调度运行时长已超阈值(Process Duration: $processDuration ms > Processing Threshold: $batchProcessThreshold ms)
+       |  单独关闭该类型警报可设置 $BATCH_DELAY_RATIO 的值
+     """.stripMargin
+  }
+
+  protected def jobErrorContent(jobErrorReason: String): String = {
+    s"""
+       |$STREAMING_JOB_ERROR
+       |
+       |作业名: $appName
+       |作业ID: $applicationId
+       |诊断信息:
+       |  (长度限制: $failureReasonLimit)
+       |  ${getLimitFailureReason(jobErrorReason)}
+       |  单独关闭该类型警报可设置$JOB_NOTICE_ENABLE=false
+     """.stripMargin
   }
 
   protected def appFailContent(startTime: String, endTime: String): String = {
@@ -133,7 +202,19 @@ trait StreamingAlarmListener extends SparkListener with StreamingListener {
        |诊断信息:
        |  [SparkContext]终止与[StreamingContext]之前，尝试终止StreamingContext
        |  如进程无法正常退出，可尝试设置$FORCE_EXIT，强制退出（不推荐）
-         """.stripMargin
+     """.stripMargin
   }
+}
+object StreamingAlarmListener {
+  // The length limit for failureReason to sent
+  val failureReasonLimit: Int = 200
 
+  def getLimitFailureReason(failureReason: String): String = {
+    val nextLineIndex = failureReason.indexOf("\n", failureReasonLimit)
+    if (nextLineIndex == -1) {
+      failureReason
+    } else {
+      failureReason.substring(0, nextLineIndex)
+    }
+  }
 }

--- a/streaming-alarmer/src/main/scala/com/netease/spark/alarm/alarmer/streaming/package.scala
+++ b/streaming-alarmer/src/main/scala/com/netease/spark/alarm/alarmer/streaming/package.scala
@@ -7,5 +7,6 @@ package object streaming {
   val BATCH_NOTICE_ENABLE: String = PREFIX + "batch.error.enable"
   val BATCH_DELAY_RATIO: String = PREFIX + "batch.delay.ratio"
   val BATCH_PROCESS_TIME: String = PREFIX + "batch.process.time.threshold"
+  val JOB_NOTICE_ENABLE: String = PREFIX + "job.error.enable"
 
 }

--- a/streaming-alarmer/src/test/scala/com/netease/spark/alarm/alarmer/streaming/StreamingAlarmListenerTest.scala
+++ b/streaming-alarmer/src/test/scala/com/netease/spark/alarm/alarmer/streaming/StreamingAlarmListenerTest.scala
@@ -1,0 +1,44 @@
+package com.netease.spark.alarm.alarmer.streaming
+
+import org.scalatest.FunSuite
+
+import scala.reflect.runtime.{universe => ru}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Try}
+
+class StreamingAlarmListenerTest extends FunSuite {
+  test("test get limit failure reason") {
+    val className = "com.netease.spark.alarm.alarmer.streaming.StreamingAlarmListener"
+    val fieldName = "failureReasonLimit"
+    setStaticFieldValue(className, fieldName, 10)
+
+    // length = 0
+    val reason0 = ""
+    // length < limit
+    val reason1 = "Failed"
+    // length > limit
+    val reason2 = "Task Failed with Exception"
+    // length > limit with multi lines
+    val reason3 = "Task Failed with Exception\n\tjava.io.IOException"
+
+    assert(StreamingAlarmListener.getLimitFailureReason(reason0) === reason0)
+    assert(StreamingAlarmListener.getLimitFailureReason(reason1) === reason1)
+    assert(StreamingAlarmListener.getLimitFailureReason(reason2) === reason2)
+    assert(StreamingAlarmListener.getLimitFailureReason(reason3) === reason3.split("\n")(0))
+  }
+
+  def setStaticFieldValue(className: String, fieldName: String, value: Any): Unit = {
+    Try {
+      val mirror = ru.runtimeMirror(getClass.getClassLoader)
+      val moduleSymbol = mirror.staticModule(className)
+      val moduleMirror = mirror.reflectModule(moduleSymbol)
+      val instanceMirror = mirror.reflect(moduleMirror.instance)
+      val limitField = moduleSymbol.typeSignature.decl(ru.TermName(fieldName))
+      val limit = instanceMirror.reflectField(limitField.asTerm)
+      limit.set(value)
+    } match {
+      case Failure(e) => e.printStackTrace()
+      case _ =>
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this PR, I add alert message notification for job error and we can enable it with setting spark.alarm.streaming.job.error.enable=true.
I also add batch process timeout notification when the batch has been running more than processThreshold.

## How was this patch tested?
manual test & unit test